### PR TITLE
added optional percentage and image index for "each" function call

### DIFF
--- a/jquery.imgpreload.js
+++ b/jquery.imgpreload.js
@@ -36,9 +36,9 @@ if ('undefined' != typeof jQuery)
 	(function($){
 
 		// extend jquery (because i love jQuery)
-		$.imgpreload = function (imgs,settings)
+		$.imgpreload = function (imgs, settings)
 		{
-			settings = $.extend({},$.fn.imgpreload.defaults,(settings instanceof Function)?{all:settings}:settings);
+			settings = $.extend({}, $.fn.imgpreload.defaults, (settings instanceof Function) ? {all:settings} : settings);
 
 			// use of typeof required
 			// https://developer.mozilla.org/En/Core_JavaScript_1.5_Reference/Operators/Special_Operators/Instanceof_Operator#Description
@@ -46,7 +46,9 @@ if ('undefined' != typeof jQuery)
 
 			var loaded = new Array();
 
-			$.each(imgs,function(i,elem)
+			var index = 0;
+
+			$.each(imgs,function(i, elem)
 			{
 				var img = new Image();
 
@@ -56,7 +58,7 @@ if ('undefined' != typeof jQuery)
 
 				if ('string' != typeof elem)
 				{
-					url = $(elem).attr('src') || $(elem).css('background-image').replace(/^url\((?:"|')?(.*)(?:'|")?\)$/mg, "$1");
+					url = $(elem).attr('src') || $(elem).css('background-image').replace(/^url\((?:"|')?(.*)(?:'|")?\)$/mg, '$1');
 
 					img_obj = elem;
 				}
@@ -65,9 +67,15 @@ if ('undefined' != typeof jQuery)
 				{
 					loaded.push(img_obj);
 
-					$.data(img_obj, 'loaded', ('error'==e.type)?false:true);
-					
-					if (settings.each instanceof Function) { settings.each.call(img_obj); }
+					$.data(img_obj, 'loaded', ('error' == e.type) ? false : true);
+
+					if (settings.each instanceof Function) {
+						var percentage = (index * 100 / imgs.length).toFixed(2);
+
+						settings.each.call(img_obj, percentage, index);
+
+						index++;
+					}
 
 					// http://jsperf.com/length-in-a-variable
 					if (loaded.length>=imgs.length && settings.all instanceof Function) { settings.all.call(loaded); }

--- a/jquery.imgpreload.js
+++ b/jquery.imgpreload.js
@@ -70,7 +70,7 @@ if ('undefined' != typeof jQuery)
 					$.data(img_obj, 'loaded', ('error' == e.type) ? false : true);
 
 					if (settings.each instanceof Function) {
-						var percentage = (index * 100 / imgs.length).toFixed(2);
+						var percentage = ((index + 1) * 100 / imgs.length).toFixed(2);
 
 						settings.each.call(img_obj, percentage, index);
 


### PR DESCRIPTION
I needed this to show the preloader progress, also people are asking for this sometimes.

How to use: 

```
$.imgpreload([
    'http://lorempixel.com/1/1',
    'http://lorempixel.com/1/2',
    'http://lorempixel.com/1/3'
], {
    each: function (percentage, index) {
        console.log(percentage, index);
    }
});
```

Will return: 

```
33.33 0
66.67 1
100.00 2 
```

Also guys — http://www.lotterypost.com/js-compress.aspx — Microsoft minifier compresses the code just a little bit better :)

Cheers.
