### PR TITLE
Make checks more bullet proof

### DIFF
--- a/dist/jquery.imgpreload.js
+++ b/dist/jquery.imgpreload.js
@@ -1,70 +1,70 @@
 /**
-* jquery.imgpreload 1.6.2 <https://github.com/farinspace/jquery.imgpreload>
-* Copyright 2009-2014 Dimas Begunoff <http://farinspace.com>
+* jquery.imgpreload 1.6.3 <https://github.com/farinspace/jquery.imgpreload>
+* Copyright 2009-2015 Dimas Begunoff <http://farinspace.com>
 * License MIT <http://opensource.org/licenses/MIT>
 */
-if ('undefined' != typeof jQuery)
+if ('undefined' !== typeof jQuery)
 {
-	(function($){
-		'use strict';
+    (function($){
+        'use strict';
 
-		// extend jquery (because i love jQuery)
-		$.imgpreload = function (imgs,settings)
-		{
-			settings = $.extend({},$.fn.imgpreload.defaults,(settings instanceof Function)?{all:settings}:settings);
+        // extend jquery (because i love jQuery)
+        $.imgpreload = function (imgs,settings)
+        {
+            settings = $.extend({},$.fn.imgpreload.defaults, (typeof settings === 'function')? {all:settings} : settings);
 
-			// use of typeof required
-			// https://developer.mozilla.org/En/Core_JavaScript_1.5_Reference/Operators/Special_Operators/Instanceof_Operator#Description
-			if ('string' == typeof imgs) { imgs = [imgs]; }
+            // use of typeof required
+            // https://developer.mozilla.org/En/Core_JavaScript_1.5_Reference/Operators/Special_Operators/Instanceof_Operator#Description
+            if ('string' == typeof imgs) { imgs = [imgs]; }
 
-			var loaded = [];
+            var loaded = [];
 
-			$.each(imgs,function(i,elem)
-			{
-				var img = new Image();
+            $.each(imgs,function(i,elem)
+            {
+                var img = new Image();
 
-				var url = elem;
+                var url = elem;
 
-				var img_obj = img;
+                var img_obj = img;
 
-				if ('string' != typeof elem)
-				{
-					url = $(elem).attr('src') || $(elem).css('background-image').replace(/^url\((?:"|')?(.*)(?:'|")?\)$/mg, "$1");
+                if ('string' != typeof elem)
+                {
+                    url = $(elem).attr('src') || $(elem).css('background-image').replace(/^url\((?:"|')?(.*)(?:'|")?\)$/mg, "$1");
 
-					img_obj = elem;
-				}
+                    img_obj = elem;
+                }
 
-				$(img).bind('load error', function(e)
-				{
-					loaded.push(img_obj);
+                $(img).bind('load error', function(e)
+                {
+                    loaded.push(img_obj);
 
-					$.data(img_obj, 'loaded', ('error'==e.type)?false:true);
+                    $.data(img_obj, 'loaded', ('error' != e.type));
 
-					// http://msdn.microsoft.com/en-us/library/ie/tkcsy6fe(v=vs.94).aspx
-					if (settings.each instanceof Function) { settings.each.call(img_obj, loaded.slice(0)); }
+                    // http://msdn.microsoft.com/en-us/library/ie/tkcsy6fe(v=vs.94).aspx
+                    if (typeof settings.each === 'function') { settings.each.call(img_obj, loaded.slice(0)); }
 
-					// http://jsperf.com/length-in-a-variable
-					if (loaded.length>=imgs.length && settings.all instanceof Function) { settings.all.call(loaded); }
+                    // http://jsperf.com/length-in-a-variable
+                    if (loaded.length>=imgs.length && typeof settings.all === 'function') { settings.all.call(loaded); }
 
-					$(this).unbind('load error');
-				});
+                    $(this).unbind('load error');
+                });
 
-				img.src = url;
-			});
-		};
+                img.src = url;
+            });
+        };
 
-		$.fn.imgpreload = function(settings)
-		{
-			$.imgpreload(this,settings);
+        $.fn.imgpreload = function(settings)
+        {
+            $.imgpreload(this,settings);
 
-			return this;
-		};
+            return this;
+        };
 
-		$.fn.imgpreload.defaults =
-		{
-			each: null, // callback invoked when each image is loaded
-			all: null // callback invoked when all images have loaded
-		};
+        $.fn.imgpreload.defaults =
+        {
+            each: null, // callback invoked when each image is loaded
+            all: null // callback invoked when all images have loaded
+        };
 
-	})(jQuery);
+    })(jQuery);
 }

--- a/dist/jquery.imgpreload.min.js
+++ b/dist/jquery.imgpreload.min.js
@@ -1,6 +1,6 @@
 /**
-* jquery.imgpreload 1.6.2 <https://github.com/farinspace/jquery.imgpreload>
-* Copyright 2009-2014 Dimas Begunoff <http://farinspace.com>
+* jquery.imgpreload 1.6.3 <https://github.com/farinspace/jquery.imgpreload>
+* Copyright 2009-2015 Dimas Begunoff <http://farinspace.com>
 * License MIT <http://opensource.org/licenses/MIT>
 */
-"undefined"!=typeof jQuery&&!function(a){"use strict";a.imgpreload=function(b,c){c=a.extend({},a.fn.imgpreload.defaults,c instanceof Function?{all:c}:c),"string"==typeof b&&(b=[b]);var d=[];a.each(b,function(e,f){var g=new Image,h=f,i=g;"string"!=typeof f&&(h=a(f).attr("src")||a(f).css("background-image").replace(/^url\((?:"|')?(.*)(?:'|")?\)$/gm,"$1"),i=f),a(g).bind("load error",function(e){d.push(i),a.data(i,"loaded","error"==e.type?!1:!0),c.each instanceof Function&&c.each.call(i,d.slice(0)),d.length>=b.length&&c.all instanceof Function&&c.all.call(d),a(this).unbind("load error")}),g.src=h})},a.fn.imgpreload=function(b){return a.imgpreload(this,b),this},a.fn.imgpreload.defaults={each:null,all:null}}(jQuery);
+"undefined"!=typeof jQuery&&!function(a){"use strict";a.imgpreload=function(b,c){c=a.extend({},a.fn.imgpreload.defaults,"function"==typeof c?{all:c}:c),"string"==typeof b&&(b=[b]);var d=[];a.each(b,function(e,f){var g=new Image,h=f,i=g;"string"!=typeof f&&(h=a(f).attr("src")||a(f).css("background-image").replace(/^url\((?:"|')?(.*)(?:'|")?\)$/gm,"$1"),i=f),a(g).bind("load error",function(e){d.push(i),a.data(i,"loaded","error"!=e.type),"function"==typeof c.each&&c.each.call(i,d.slice(0)),d.length>=b.length&&"function"==typeof c.all&&c.all.call(d),a(this).unbind("load error")}),g.src=h})},a.fn.imgpreload=function(b){return a.imgpreload(this,b),this},a.fn.imgpreload.defaults={each:null,all:null}}(jQuery);

--- a/jquery.imgpreload.js
+++ b/jquery.imgpreload.js
@@ -1,70 +1,70 @@
 /**
-* jquery.imgpreload 1.6.2 <https://github.com/farinspace/jquery.imgpreload>
-* Copyright 2009-2014 Dimas Begunoff <http://farinspace.com>
+* jquery.imgpreload 1.6.3 <https://github.com/farinspace/jquery.imgpreload>
+* Copyright 2009-2015 Dimas Begunoff <http://farinspace.com>
 * License MIT <http://opensource.org/licenses/MIT>
 */
-if ('undefined' != typeof jQuery)
+if ('undefined' !== typeof jQuery)
 {
-	(function($){
-		'use strict';
+    (function($){
+        'use strict';
 
-		// extend jquery (because i love jQuery)
-		$.imgpreload = function (imgs,settings)
-		{
-			settings = $.extend({},$.fn.imgpreload.defaults,(settings instanceof Function)?{all:settings}:settings);
+        // extend jquery (because i love jQuery)
+        $.imgpreload = function (imgs,settings)
+        {
+            settings = $.extend({},$.fn.imgpreload.defaults, (typeof settings === 'function')? {all:settings} : settings);
 
-			// use of typeof required
-			// https://developer.mozilla.org/En/Core_JavaScript_1.5_Reference/Operators/Special_Operators/Instanceof_Operator#Description
-			if ('string' == typeof imgs) { imgs = [imgs]; }
+            // use of typeof required
+            // https://developer.mozilla.org/En/Core_JavaScript_1.5_Reference/Operators/Special_Operators/Instanceof_Operator#Description
+            if ('string' == typeof imgs) { imgs = [imgs]; }
 
-			var loaded = [];
+            var loaded = [];
 
-			$.each(imgs,function(i,elem)
-			{
-				var img = new Image();
+            $.each(imgs,function(i,elem)
+            {
+                var img = new Image();
 
-				var url = elem;
+                var url = elem;
 
-				var img_obj = img;
+                var img_obj = img;
 
-				if ('string' != typeof elem)
-				{
-					url = $(elem).attr('src') || $(elem).css('background-image').replace(/^url\((?:"|')?(.*)(?:'|")?\)$/mg, "$1");
+                if ('string' != typeof elem)
+                {
+                    url = $(elem).attr('src') || $(elem).css('background-image').replace(/^url\((?:"|')?(.*)(?:'|")?\)$/mg, "$1");
 
-					img_obj = elem;
-				}
+                    img_obj = elem;
+                }
 
-				$(img).bind('load error', function(e)
-				{
-					loaded.push(img_obj);
+                $(img).bind('load error', function(e)
+                {
+                    loaded.push(img_obj);
 
-					$.data(img_obj, 'loaded', ('error'==e.type)?false:true);
+                    $.data(img_obj, 'loaded', ('error' != e.type));
 
-					// http://msdn.microsoft.com/en-us/library/ie/tkcsy6fe(v=vs.94).aspx
-					if (settings.each instanceof Function) { settings.each.call(img_obj, loaded.slice(0)); }
+                    // http://msdn.microsoft.com/en-us/library/ie/tkcsy6fe(v=vs.94).aspx
+                    if (typeof settings.each === 'function') { settings.each.call(img_obj, loaded.slice(0)); }
 
-					// http://jsperf.com/length-in-a-variable
-					if (loaded.length>=imgs.length && settings.all instanceof Function) { settings.all.call(loaded); }
+                    // http://jsperf.com/length-in-a-variable
+                    if (loaded.length>=imgs.length && typeof settings.all === 'function') { settings.all.call(loaded); }
 
-					$(this).unbind('load error');
-				});
+                    $(this).unbind('load error');
+                });
 
-				img.src = url;
-			});
-		};
+                img.src = url;
+            });
+        };
 
-		$.fn.imgpreload = function(settings)
-		{
-			$.imgpreload(this,settings);
+        $.fn.imgpreload = function(settings)
+        {
+            $.imgpreload(this,settings);
 
-			return this;
-		};
+            return this;
+        };
 
-		$.fn.imgpreload.defaults =
-		{
-			each: null, // callback invoked when each image is loaded
-			all: null // callback invoked when all images have loaded
-		};
+        $.fn.imgpreload.defaults =
+        {
+            each: null, // callback invoked when each image is loaded
+            all: null // callback invoked when all images have loaded
+        };
 
-	})(jQuery);
+    })(jQuery);
 }

--- a/jquery.imgpreload.min.js
+++ b/jquery.imgpreload.min.js
@@ -1,6 +1,6 @@
 /**
-* jquery.imgpreload 1.6.2 <https://github.com/farinspace/jquery.imgpreload>
-* Copyright 2009-2014 Dimas Begunoff <http://farinspace.com>
+* jquery.imgpreload 1.6.3 <https://github.com/farinspace/jquery.imgpreload>
+* Copyright 2009-2015 Dimas Begunoff <http://farinspace.com>
 * License MIT <http://opensource.org/licenses/MIT>
 */
-"undefined"!=typeof jQuery&&!function(a){"use strict";a.imgpreload=function(b,c){c=a.extend({},a.fn.imgpreload.defaults,c instanceof Function?{all:c}:c),"string"==typeof b&&(b=[b]);var d=[];a.each(b,function(e,f){var g=new Image,h=f,i=g;"string"!=typeof f&&(h=a(f).attr("src")||a(f).css("background-image").replace(/^url\((?:"|')?(.*)(?:'|")?\)$/gm,"$1"),i=f),a(g).bind("load error",function(e){d.push(i),a.data(i,"loaded","error"==e.type?!1:!0),c.each instanceof Function&&c.each.call(i,d.slice(0)),d.length>=b.length&&c.all instanceof Function&&c.all.call(d),a(this).unbind("load error")}),g.src=h})},a.fn.imgpreload=function(b){return a.imgpreload(this,b),this},a.fn.imgpreload.defaults={each:null,all:null}}(jQuery);
+"undefined"!=typeof jQuery&&!function(a){"use strict";a.imgpreload=function(b,c){c=a.extend({},a.fn.imgpreload.defaults,"function"==typeof c?{all:c}:c),"string"==typeof b&&(b=[b]);var d=[];a.each(b,function(e,f){var g=new Image,h=f,i=g;"string"!=typeof f&&(h=a(f).attr("src")||a(f).css("background-image").replace(/^url\((?:"|')?(.*)(?:'|")?\)$/gm,"$1"),i=f),a(g).bind("load error",function(e){d.push(i),a.data(i,"loaded","error"!=e.type),"function"==typeof c.each&&c.each.call(i,d.slice(0)),d.length>=b.length&&"function"==typeof c.all&&c.all.call(d),a(this).unbind("load error")}),g.src=h})},a.fn.imgpreload=function(b){return a.imgpreload(this,b),this},a.fn.imgpreload.defaults={each:null,all:null}}(jQuery);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery.imgpreload",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "MIT",
   "licenses": [
     {


### PR DESCRIPTION
There exists some edge cases that can cause naive `x instance of Function` checks to don't work.

Examples:

```
var z = document.createElement('iframe');
document.body.appendChild(z);
console.log(z.contentWindow.Array.prototype.forEach instance of Function) // false
Function = null;
jQuery instanceof Function; // TypeError: invalid 'instanceof' operand Function
Function = Array;
jQuery instanceof Function; // false
```

These edge cases were replaced by more robust `typeof` check.

Tabs was replaced with spaces.

`a == b ? false : true`  was replaced with `a != b`
